### PR TITLE
Review fixes for "Make play() run in a separate thread (#1500)"

### DIFF
--- a/rosbag2_py/src/rosbag2_py/_transport.cpp
+++ b/rosbag2_py/src/rosbag2_py/_transport.cpp
@@ -155,7 +155,7 @@ public:
         exec.spin();
       });
     player->play();
-    player->wait_for_playback_to_end();
+    player->wait_for_playback_to_finish();
 
     exec.cancel();
     spin_thread.join();

--- a/rosbag2_transport/include/rosbag2_transport/player.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/player.hpp
@@ -117,9 +117,13 @@ public:
   ROSBAG2_TRANSPORT_PUBLIC
   bool play();
 
-  /// \brief Blocks and waits on the condition variable until the play thread finishes
+  /// \brief Waits on the condition variable until the play thread finishes.
+  /// @param timeout Maximum time in the fraction of seconds to wait for player to finish.
+  /// If timeout is negative, the wait_for_playback_to_finish will be a blocking call.
+  /// @return true if playback finished during timeout, otherwise false.
   ROSBAG2_TRANSPORT_PUBLIC
-  void wait_for_playback_to_finish();
+  bool wait_for_playback_to_finish(
+    std::chrono::duration<double> timeout = std::chrono::seconds(-1));
 
   /// \brief Unpause if in pause mode, stop playback and exit from play.
   ROSBAG2_TRANSPORT_PUBLIC

--- a/rosbag2_transport/include/rosbag2_transport/player.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/player.hpp
@@ -20,7 +20,6 @@
 #include <functional>
 #include <future>
 #include <memory>
-#include <queue>
 #include <string>
 #include <unordered_map>
 #include <utility>

--- a/rosbag2_transport/include/rosbag2_transport/player.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/player.hpp
@@ -113,6 +113,8 @@ public:
   ROSBAG2_TRANSPORT_PUBLIC
   virtual ~Player();
 
+  /// \brief Start playback asynchronously in a separate thread
+  /// \return false if playback thread already running, otherwise true
   ROSBAG2_TRANSPORT_PUBLIC
   bool play();
 

--- a/rosbag2_transport/include/rosbag2_transport/player.hpp
+++ b/rosbag2_transport/include/rosbag2_transport/player.hpp
@@ -118,9 +118,9 @@ public:
   ROSBAG2_TRANSPORT_PUBLIC
   bool play();
 
-  /// \brief Blocks and wait on condition variable until the play thread stops
+  /// \brief Blocks and waits on the condition variable until the play thread finishes
   ROSBAG2_TRANSPORT_PUBLIC
-  void wait_for_playback_to_end();
+  void wait_for_playback_to_finish();
 
   /// \brief Unpause if in pause mode, stop playback and exit from play.
   ROSBAG2_TRANSPORT_PUBLIC

--- a/rosbag2_transport/src/rosbag2_transport/player.cpp
+++ b/rosbag2_transport/src/rosbag2_transport/player.cpp
@@ -193,7 +193,7 @@ public:
   void wait_for_playback_to_start();
 
   /// \brief Blocks and wait on condition variable until the play thread stops
-  void wait_for_playback_to_end();
+  void wait_for_playback_to_finish();
 
   /// \brief Getter for the number of registered on_play_msg_pre_callbacks
   /// \return Number of registered on_play_msg_pre_callbacks
@@ -500,7 +500,7 @@ bool PlayerImpl::play()
   return true;
 }
 
-void PlayerImpl::wait_for_playback_to_end()
+void PlayerImpl::wait_for_playback_to_finish()
 {
   std::unique_lock<std::mutex> is_in_playback_lk(is_in_playback_mutex_);
   playback_finished_cv_.wait(is_in_playback_lk, [this] {return !is_in_playback_.load();});
@@ -1275,9 +1275,9 @@ bool Player::play()
   return pimpl_->play();
 }
 
-void Player::wait_for_playback_to_end()
+void Player::wait_for_playback_to_finish()
 {
-  return pimpl_->wait_for_playback_to_end();
+  return pimpl_->wait_for_playback_to_finish();
 }
 
 void Player::stop()

--- a/rosbag2_transport/test/rosbag2_transport/rosbag2_play_duration_until_fixture.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/rosbag2_play_duration_until_fixture.hpp
@@ -176,12 +176,8 @@ public:
           std::chrono::seconds(5)));
 
       auto await_received_messages = test_fixture_->sub_->spin_subscriptions();
-      auto player_future = std::async(
-        std::launch::async, [&] {
-          test_fixture_->player_->wait_for_playback_to_end();
-        });
       ASSERT_TRUE(test_fixture_->player_->play());
-      player_future.get();
+      test_fixture_->player_->wait_for_playback_to_end();
       await_received_messages.get();
     }
 

--- a/rosbag2_transport/test/rosbag2_transport/rosbag2_play_duration_until_fixture.hpp
+++ b/rosbag2_transport/test/rosbag2_transport/rosbag2_play_duration_until_fixture.hpp
@@ -177,7 +177,7 @@ public:
 
       auto await_received_messages = test_fixture_->sub_->spin_subscriptions();
       ASSERT_TRUE(test_fixture_->player_->play());
-      test_fixture_->player_->wait_for_playback_to_end();
+      test_fixture_->player_->wait_for_playback_to_finish();
       await_received_messages.get();
     }
 

--- a/rosbag2_transport/test/rosbag2_transport/test_burst.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_burst.cpp
@@ -83,7 +83,6 @@ TEST_F(RosBag2PlayTestFixture, burst_bursts_requested_messages_without_delays) {
   player->pause();
   ASSERT_TRUE(player->is_paused());
 
-  auto player_future = std::async(std::launch::async, [&] {player->wait_for_playback_to_end();});
   player->play();
   player->wait_for_playback_to_start();
 
@@ -98,7 +97,8 @@ TEST_F(RosBag2PlayTestFixture, burst_bursts_requested_messages_without_delays) {
 
   ASSERT_TRUE(player->is_paused());
   player->resume();
-  player_future.get();
+  player->wait_for_playback_to_end();
+
   await_received_messages.get();
 
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1");
@@ -137,7 +137,6 @@ TEST_F(RosBag2PlayTestFixture, burst_stops_at_end_of_file) {
   player->pause();
   ASSERT_TRUE(player->is_paused());
 
-  auto player_future = std::async(std::launch::async, [&] {player->wait_for_playback_to_end();});
   player->play();
   player->wait_for_playback_to_start();
 
@@ -146,7 +145,7 @@ TEST_F(RosBag2PlayTestFixture, burst_stops_at_end_of_file) {
   ASSERT_EQ(played_messages, messages.size());
   ASSERT_TRUE(player->is_paused());
   player->resume();
-  player_future.get();
+  player->wait_for_playback_to_end();
   await_received_messages.get();
 
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1");
@@ -185,7 +184,6 @@ TEST_F(RosBag2PlayTestFixture, burst_bursting_one_by_one_messages_with_the_same_
   player->pause();
   ASSERT_TRUE(player->is_paused());
 
-  auto player_future = std::async(std::launch::async, [&] {player->wait_for_playback_to_end();});
   player->play();
 
   ASSERT_TRUE(player->is_paused());
@@ -194,12 +192,13 @@ TEST_F(RosBag2PlayTestFixture, burst_bursting_one_by_one_messages_with_the_same_
   while (player->burst(1) == 1) {
     // Yield CPU resources for player-play() running in separate thread to make sure that it
     // will not play extra messages.
+    std::this_thread::sleep_for(std::chrono::milliseconds(30));
     played_messages++;
   }
   ASSERT_EQ(played_messages, messages.size());
   ASSERT_TRUE(player->is_paused());
   player->resume();
-  player_future.get();
+  player->wait_for_playback_to_end();
   await_received_messages.get();
 
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1");
@@ -238,7 +237,6 @@ TEST_F(RosBag2PlayTestFixture, play_respect_messages_timing_after_burst) {
   player->pause();
   ASSERT_TRUE(player->is_paused());
 
-  auto player_future = std::async(std::launch::async, [&] {player->wait_for_playback_to_end();});
   player->play();
 
   const size_t EXPECTED_BURST_COUNT = 2;
@@ -247,7 +245,7 @@ TEST_F(RosBag2PlayTestFixture, play_respect_messages_timing_after_burst) {
   ASSERT_TRUE(player->is_paused());
   player->resume();
   auto start = std::chrono::steady_clock::now();
-  player_future.get();
+  player->wait_for_playback_to_end();
   auto replay_time = std::chrono::steady_clock::now() - start;
 
   auto expected_replay_time =
@@ -293,14 +291,13 @@ TEST_F(RosBag2PlayTestFixture, player_can_resume_after_burst) {
   player->pause();
   ASSERT_TRUE(player->is_paused());
 
-  auto player_future = std::async(std::launch::async, [&] {player->wait_for_playback_to_end();});
   player->play();
 
   ASSERT_TRUE(player->is_paused());
   ASSERT_EQ(player->burst(1), 1u);
   ASSERT_TRUE(player->is_paused());
   player->resume();
-  player_future.get();
+  player->wait_for_playback_to_end();
   await_received_messages.get();
 
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1");
@@ -350,7 +347,6 @@ TEST_F(RosBag2PlayTestFixture, burst_bursting_only_filtered_topics) {
   player->pause();
   ASSERT_TRUE(player->is_paused());
 
-  auto player_future = std::async(std::launch::async, [&] {player->wait_for_playback_to_end();});
   player->play();
   ASSERT_TRUE(player->is_paused());
 
@@ -359,7 +355,7 @@ TEST_F(RosBag2PlayTestFixture, burst_bursting_only_filtered_topics) {
 
   ASSERT_TRUE(player->is_paused());
   player->resume();
-  player_future.get();
+  player->wait_for_playback_to_end();
   await_received_messages.get();
 
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1");

--- a/rosbag2_transport/test/rosbag2_transport/test_burst.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_burst.cpp
@@ -97,7 +97,7 @@ TEST_F(RosBag2PlayTestFixture, burst_bursts_requested_messages_without_delays) {
 
   ASSERT_TRUE(player->is_paused());
   player->resume();
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
 
   await_received_messages.get();
 
@@ -145,7 +145,7 @@ TEST_F(RosBag2PlayTestFixture, burst_stops_at_end_of_file) {
   ASSERT_EQ(played_messages, messages.size());
   ASSERT_TRUE(player->is_paused());
   player->resume();
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
   await_received_messages.get();
 
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1");
@@ -198,7 +198,7 @@ TEST_F(RosBag2PlayTestFixture, burst_bursting_one_by_one_messages_with_the_same_
   ASSERT_EQ(played_messages, messages.size());
   ASSERT_TRUE(player->is_paused());
   player->resume();
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
   await_received_messages.get();
 
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1");
@@ -245,7 +245,7 @@ TEST_F(RosBag2PlayTestFixture, play_respect_messages_timing_after_burst) {
   ASSERT_TRUE(player->is_paused());
   player->resume();
   auto start = std::chrono::steady_clock::now();
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
   auto replay_time = std::chrono::steady_clock::now() - start;
 
   auto expected_replay_time =
@@ -297,7 +297,7 @@ TEST_F(RosBag2PlayTestFixture, player_can_resume_after_burst) {
   ASSERT_EQ(player->burst(1), 1u);
   ASSERT_TRUE(player->is_paused());
   player->resume();
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
   await_received_messages.get();
 
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1");
@@ -355,7 +355,7 @@ TEST_F(RosBag2PlayTestFixture, burst_bursting_only_filtered_topics) {
 
   ASSERT_TRUE(player->is_paused());
   player->resume();
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
   await_received_messages.get();
 
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1");

--- a/rosbag2_transport/test/rosbag2_transport/test_keyboard_controls.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_keyboard_controls.cpp
@@ -160,7 +160,7 @@ TEST_F(RosBag2PlayTestFixture, test_keyboard_controls)
   keyboard_handler->simulate_key_press(play_options_.increase_rate_key);
   keyboard_handler->simulate_key_press(play_options_.decrease_rate_key);
 
-  // start play thread
+  // start playback asynchronously in a separate thread
   player->play();
 
   // play next

--- a/rosbag2_transport/test/rosbag2_transport/test_play.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play.cpp
@@ -79,7 +79,7 @@ TEST_F(RosBag2PlayTestFixture, recorded_messages_are_played_for_all_topics)
   auto player = std::make_shared<rosbag2_transport::Player>(
     std::move(reader), storage_options_, play_options_);
   player->play();
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
   await_received_messages.get();
 
   auto replayed_test_primitives = sub_->get_received_messages<test_msgs::msg::BasicTypes>(
@@ -149,7 +149,7 @@ TEST_F(RosBag2PlayTestFixture, recorded_messages_are_played_for_all_topics_with_
   auto player = std::make_shared<rosbag2_transport::Player>(
     std::move(reader), storage_options_, play_options_);
   player->play();
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
   await_received_messages.get();
 
   auto replayed_test_primitives = sub_->get_received_messages<test_msgs::msg::BasicTypes>(
@@ -220,7 +220,7 @@ TEST_F(RosBag2PlayTestFixture, recorded_messages_are_played_for_filtered_topics)
     auto player = std::make_shared<rosbag2_transport::Player>(
       std::move(reader), storage_options_, play_options_);
     player->play();
-    player->wait_for_playback_to_end();
+    player->wait_for_playback_to_finish();
     await_received_messages.get();
 
     auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1");
@@ -252,7 +252,7 @@ TEST_F(RosBag2PlayTestFixture, recorded_messages_are_played_for_filtered_topics)
     auto player = std::make_shared<rosbag2_transport::Player>(
       std::move(reader), storage_options_, play_options_);
     player->play();
-    player->wait_for_playback_to_end();
+    player->wait_for_playback_to_finish();
     await_received_messages.get();
 
     auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1");
@@ -284,7 +284,7 @@ TEST_F(RosBag2PlayTestFixture, recorded_messages_are_played_for_filtered_topics)
     auto player = std::make_shared<rosbag2_transport::Player>(
       std::move(reader), storage_options_, play_options_);
     player->play();
-    player->wait_for_playback_to_end();
+    player->wait_for_playback_to_finish();
     await_received_messages.get();
 
     auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1");
@@ -340,7 +340,7 @@ TEST_F(RosBag2PlayTestFixture, recorded_messages_are_played_for_filtered_topics_
     auto player = std::make_shared<rosbag2_transport::Player>(
       std::move(reader), storage_options_, play_options_);
     player->play();
-    player->wait_for_playback_to_end();
+    player->wait_for_playback_to_finish();
     await_received_messages.get();
 
     auto replayed_test_primitives = sub_->get_received_messages<test_msgs::msg::BasicTypes>(
@@ -369,7 +369,7 @@ TEST_F(RosBag2PlayTestFixture, recorded_messages_are_played_for_filtered_topics_
     auto player = std::make_shared<rosbag2_transport::Player>(
       std::move(reader), storage_options_, play_options_);
     player->play();
-    player->wait_for_playback_to_end();
+    player->wait_for_playback_to_finish();
     await_received_messages.get();
 
     auto replayed_test_primitives = sub_->get_received_messages<test_msgs::msg::BasicTypes>(
@@ -399,7 +399,7 @@ TEST_F(RosBag2PlayTestFixture, recorded_messages_are_played_for_filtered_topics_
     auto player = std::make_shared<rosbag2_transport::Player>(
       std::move(reader), storage_options_, play_options_);
     player->play();
-    player->wait_for_playback_to_end();
+    player->wait_for_playback_to_finish();
     await_received_messages.get();
 
     auto replayed_test_primitives = sub_->get_received_messages<test_msgs::msg::BasicTypes>(
@@ -436,7 +436,7 @@ TEST_F(RosBag2PlayTestFixture, player_gracefully_exit_by_rclcpp_shutdown_in_paus
   ASSERT_TRUE(player->is_paused());
 
   rclcpp::shutdown();
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
 }
 
 class RosBag2PlayQosOverrideTestFixture : public RosBag2PlayTestFixture
@@ -481,7 +481,7 @@ public:
     auto player = std::make_shared<rosbag2_transport::Player>(
       std::move(reader), storage_options_, play_options_);
     player->play();
-    player->wait_for_playback_to_end();
+    player->wait_for_playback_to_finish();
     const auto result = await_received_messages.wait_for(timeout);
     // Must EXPECT, can't ASSERT because transport needs to be shutdown if timed out
     if (expect_timeout) {
@@ -673,7 +673,7 @@ TEST_F(RosBag2PlayTestFixture, read_split_callback_is_called)
   auto await_received_messages = sub_->spin_subscriptions();
 
   player->play();
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
   await_received_messages.get();
 
   auto replayed_test_primitives = sub_->get_received_messages<test_msgs::msg::BasicTypes>(

--- a/rosbag2_transport/test/rosbag2_transport/test_play.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play.cpp
@@ -77,8 +77,7 @@ TEST_F(RosBag2PlayTestFixture, recorded_messages_are_played_for_all_topics)
   auto await_received_messages = sub_->spin_subscriptions();
 
   auto player = std::make_shared<rosbag2_transport::Player>(
-    std::move(
-      reader), storage_options_, play_options_);
+    std::move(reader), storage_options_, play_options_);
   player->play();
   player->wait_for_playback_to_end();
   await_received_messages.get();
@@ -148,8 +147,7 @@ TEST_F(RosBag2PlayTestFixture, recorded_messages_are_played_for_all_topics_with_
   auto await_received_messages = sub_->spin_subscriptions();
 
   auto player = std::make_shared<rosbag2_transport::Player>(
-    std::move(
-      reader), storage_options_, play_options_);
+    std::move(reader), storage_options_, play_options_);
   player->play();
   player->wait_for_playback_to_end();
   await_received_messages.get();
@@ -220,8 +218,7 @@ TEST_F(RosBag2PlayTestFixture, recorded_messages_are_played_for_filtered_topics)
     auto await_received_messages = sub_->spin_subscriptions();
 
     auto player = std::make_shared<rosbag2_transport::Player>(
-      std::move(
-        reader), storage_options_, play_options_);
+      std::move(reader), storage_options_, play_options_);
     player->play();
     player->wait_for_playback_to_end();
     await_received_messages.get();
@@ -253,8 +250,7 @@ TEST_F(RosBag2PlayTestFixture, recorded_messages_are_played_for_filtered_topics)
     auto await_received_messages = sub_->spin_subscriptions();
 
     auto player = std::make_shared<rosbag2_transport::Player>(
-      std::move(
-        reader), storage_options_, play_options_);
+      std::move(reader), storage_options_, play_options_);
     player->play();
     player->wait_for_playback_to_end();
     await_received_messages.get();
@@ -286,8 +282,7 @@ TEST_F(RosBag2PlayTestFixture, recorded_messages_are_played_for_filtered_topics)
     auto await_received_messages = sub_->spin_subscriptions();
 
     auto player = std::make_shared<rosbag2_transport::Player>(
-      std::move(
-        reader), storage_options_, play_options_);
+      std::move(reader), storage_options_, play_options_);
     player->play();
     player->wait_for_playback_to_end();
     await_received_messages.get();
@@ -343,8 +338,7 @@ TEST_F(RosBag2PlayTestFixture, recorded_messages_are_played_for_filtered_topics_
     auto await_received_messages = sub_->spin_subscriptions();
 
     auto player = std::make_shared<rosbag2_transport::Player>(
-      std::move(
-        reader), storage_options_, play_options_);
+      std::move(reader), storage_options_, play_options_);
     player->play();
     player->wait_for_playback_to_end();
     await_received_messages.get();
@@ -373,8 +367,7 @@ TEST_F(RosBag2PlayTestFixture, recorded_messages_are_played_for_filtered_topics_
     auto await_received_messages = sub_->spin_subscriptions();
 
     auto player = std::make_shared<rosbag2_transport::Player>(
-      std::move(
-        reader), storage_options_, play_options_);
+      std::move(reader), storage_options_, play_options_);
     player->play();
     player->wait_for_playback_to_end();
     await_received_messages.get();
@@ -404,8 +397,7 @@ TEST_F(RosBag2PlayTestFixture, recorded_messages_are_played_for_filtered_topics_
     auto await_received_messages = sub_->spin_subscriptions();
 
     auto player = std::make_shared<rosbag2_transport::Player>(
-      std::move(
-        reader), storage_options_, play_options_);
+      std::move(reader), storage_options_, play_options_);
     player->play();
     player->wait_for_playback_to_end();
     await_received_messages.get();
@@ -439,14 +431,12 @@ TEST_F(RosBag2PlayTestFixture, player_gracefully_exit_by_rclcpp_shutdown_in_paus
   auto player = std::make_shared<MockPlayer>(std::move(reader), storage_options_, play_options_);
 
   player->pause();
-  auto player_future =
-    std::async(std::launch::async, [&] {player->wait_for_playback_to_end();});
   player->play();
   player->wait_for_playback_to_start();
   ASSERT_TRUE(player->is_paused());
 
   rclcpp::shutdown();
-  player_future.get();
+  player->wait_for_playback_to_end();
 }
 
 class RosBag2PlayQosOverrideTestFixture : public RosBag2PlayTestFixture
@@ -489,8 +479,7 @@ public:
 
     auto await_received_messages = sub_->spin_subscriptions();
     auto player = std::make_shared<rosbag2_transport::Player>(
-      std::move(
-        reader), storage_options_, play_options_);
+      std::move(reader), storage_options_, play_options_);
     player->play();
     player->wait_for_playback_to_end();
     const auto result = await_received_messages.wait_for(timeout);

--- a/rosbag2_transport/test/rosbag2_transport/test_play_callbacks.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_callbacks.cpp
@@ -110,8 +110,7 @@ TEST_F(Rosbag2PlayCallbacksTestFixture, register_unregister_callbacks) {
   player.pause();   // Put player in pause mode before starting
   ASSERT_TRUE(player.is_paused());
 
-  std::future<void> play_future_result =
-    std::async(std::launch::async, [&] {player.wait_for_playback_to_end();});
+  // Run playback asynchronously in a separate thread
   player.play();
 
   for (size_t i = 1; i < num_test_messages_; i++) {
@@ -119,9 +118,7 @@ TEST_F(Rosbag2PlayCallbacksTestFixture, register_unregister_callbacks) {
   }
   player.resume();   // Resume playback for playing the last message
   ASSERT_FALSE(player.is_paused());
-
-  play_future_result.wait();
-  play_future_result.get();
+  player.wait_for_playback_to_end();
   EXPECT_FALSE(player.play_next());
 }
 
@@ -148,8 +145,6 @@ TEST_F(Rosbag2PlayCallbacksTestFixture, call_callbacks) {
   player.pause();  // Put player in pause mode before starting
   ASSERT_TRUE(player.is_paused());
 
-  std::future<void> play_future_result =
-    std::async(std::launch::async, [&] {player.wait_for_playback_to_end();});
   player.play();
 
   for (size_t i = 1; i < num_test_messages_; i++) {
@@ -158,8 +153,6 @@ TEST_F(Rosbag2PlayCallbacksTestFixture, call_callbacks) {
 
   player.resume();  // Resume playback for playing the last message
   ASSERT_FALSE(player.is_paused());
-
-  play_future_result.wait();
-  play_future_result.get();
+  player.wait_for_playback_to_end();
   EXPECT_FALSE(player.play_next());
 }

--- a/rosbag2_transport/test/rosbag2_transport/test_play_callbacks.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_callbacks.cpp
@@ -118,7 +118,7 @@ TEST_F(Rosbag2PlayCallbacksTestFixture, register_unregister_callbacks) {
   }
   player.resume();   // Resume playback for playing the last message
   ASSERT_FALSE(player.is_paused());
-  player.wait_for_playback_to_end();
+  player.wait_for_playback_to_finish();
   EXPECT_FALSE(player.play_next());
 }
 
@@ -153,6 +153,6 @@ TEST_F(Rosbag2PlayCallbacksTestFixture, call_callbacks) {
 
   player.resume();  // Resume playback for playing the last message
   ASSERT_FALSE(player.is_paused());
-  player.wait_for_playback_to_end();
+  player.wait_for_playback_to_finish();
   EXPECT_FALSE(player.play_next());
 }

--- a/rosbag2_transport/test/rosbag2_transport/test_play_duration.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_duration.cpp
@@ -94,9 +94,8 @@ TEST_F(RosBag2PlayDurationTestFixture, play_for_none_are_played_due_to_duration)
     player->add_on_play_message_post_callback(mock_post_callback.AsStdFunction());
   ASSERT_NE(post_callback_handle, Player::invalid_callback_handle);
 
-  auto player_future = std::async(std::launch::async, [&] {player->wait_for_playback_to_end();});
   ASSERT_TRUE(player->play());
-  player_future.get();
+  player->wait_for_playback_to_end();
 }
 
 TEST_F(RosBag2PlayDurationTestFixture, play_for_less_than_the_total_duration)
@@ -130,19 +129,18 @@ TEST_F(RosBag2PlayDurationTestFixture, play_for_less_than_the_total_duration)
   ASSERT_TRUE(sub_->spin_and_wait_for_matched(player_->get_list_of_publishers(), 5s));
 
   auto await_received_messages = sub_->spin_subscriptions();
-  auto player_future = std::async(std::launch::async, [&] {player_->wait_for_playback_to_end();});
   player_->play();
-  player_future.get();
+  player_->wait_for_playback_to_end();
+
 
   // Playing one more time with play_next to save time and count messages
   player_->pause();
-  player_future = std::async(std::launch::async, [&] {player_->wait_for_playback_to_end();});
   player_->play();
 
   ASSERT_TRUE(player_->play_next());
   ASSERT_FALSE(player_->play_next());
   player_->resume();
-  player_future.get();
+  player_->wait_for_playback_to_end();
   await_received_messages.get();
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>(kTopic1_);
   EXPECT_THAT(replayed_topic1, SizeIs(2));
@@ -203,14 +201,13 @@ TEST_F(RosBag2PlayDurationTestFixture, play_should_return_false_when_interrupted
 
   auto await_received_messages = sub_->spin_subscriptions();
   player_->pause();
-  auto player_future = std::async(std::launch::async, [&] {player_->wait_for_playback_to_end();});
   player_->play();
   player_->wait_for_playback_to_start();
   ASSERT_TRUE(player_->is_paused());
   ASSERT_FALSE(player_->play());
 
   player_->resume();
-  player_future.get();
+  player_->wait_for_playback_to_end();
   await_received_messages.get();
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>(kTopic1_);
   EXPECT_THAT(replayed_topic1, SizeIs(1));

--- a/rosbag2_transport/test/rosbag2_transport/test_play_duration.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_duration.cpp
@@ -95,7 +95,7 @@ TEST_F(RosBag2PlayDurationTestFixture, play_for_none_are_played_due_to_duration)
   ASSERT_NE(post_callback_handle, Player::invalid_callback_handle);
 
   ASSERT_TRUE(player->play());
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
 }
 
 TEST_F(RosBag2PlayDurationTestFixture, play_for_less_than_the_total_duration)
@@ -130,7 +130,7 @@ TEST_F(RosBag2PlayDurationTestFixture, play_for_less_than_the_total_duration)
 
   auto await_received_messages = sub_->spin_subscriptions();
   player_->play();
-  player_->wait_for_playback_to_end();
+  player_->wait_for_playback_to_finish();
 
 
   // Playing one more time with play_next to save time and count messages
@@ -140,7 +140,7 @@ TEST_F(RosBag2PlayDurationTestFixture, play_for_less_than_the_total_duration)
   ASSERT_TRUE(player_->play_next());
   ASSERT_FALSE(player_->play_next());
   player_->resume();
-  player_->wait_for_playback_to_end();
+  player_->wait_for_playback_to_finish();
   await_received_messages.get();
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>(kTopic1_);
   EXPECT_THAT(replayed_topic1, SizeIs(2));
@@ -207,7 +207,7 @@ TEST_F(RosBag2PlayDurationTestFixture, play_should_return_false_when_interrupted
   ASSERT_FALSE(player_->play());
 
   player_->resume();
-  player_->wait_for_playback_to_end();
+  player_->wait_for_playback_to_finish();
   await_received_messages.get();
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>(kTopic1_);
   EXPECT_THAT(replayed_topic1, SizeIs(1));

--- a/rosbag2_transport/test/rosbag2_transport/test_play_loop.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_loop.cpp
@@ -78,10 +78,10 @@ TEST_F(RosBag2PlayTestFixture, play_bag_file_twice) {
   auto loop_thread = std::async(
     std::launch::async, [&player]() {
       player->play();
-      player->wait_for_playback_to_end();
+      player->wait_for_playback_to_finish();
       // play again the same bag file
       player->play();
-      player->wait_for_playback_to_end();
+      player->wait_for_playback_to_finish();
     });
 
   await_received_messages.get();

--- a/rosbag2_transport/test/rosbag2_transport/test_play_next.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_next.cpp
@@ -98,7 +98,7 @@ TEST_F(RosBag2PlayTestFixture, play_next_playing_all_messages_without_delays) {
   ASSERT_THAT(replay_time, Lt(std::chrono::seconds(2)));
   ASSERT_TRUE(player->is_paused());
   player->resume();
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
   await_received_messages.get();
 
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1");
@@ -151,7 +151,7 @@ TEST_F(RosBag2PlayTestFixture, play_next_playing_one_by_one_messages_with_the_sa
   ASSERT_EQ(played_messages, messages.size());
   ASSERT_TRUE(player->is_paused());
   player->resume();
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
   await_received_messages.get();
 
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1");
@@ -198,7 +198,7 @@ TEST_F(RosBag2PlayTestFixture, play_respect_messages_timing_after_play_next) {
   ASSERT_TRUE(player->is_paused());
   player->resume();
   auto start = std::chrono::steady_clock::now();
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
   auto replay_time = std::chrono::steady_clock::now() - start;
 
   auto expected_replay_time =
@@ -250,7 +250,7 @@ TEST_F(RosBag2PlayTestFixture, player_can_resume_after_play_next) {
   ASSERT_TRUE(player->play_next());
   ASSERT_TRUE(player->is_paused());
   player->resume();
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
   await_received_messages.get();
 
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1");
@@ -313,7 +313,7 @@ TEST_F(RosBag2PlayTestFixture, play_next_playing_only_filtered_topics) {
 
   ASSERT_TRUE(player->is_paused());
   player->resume();
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
   await_received_messages.get();
 
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1");

--- a/rosbag2_transport/test/rosbag2_transport/test_play_next.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_next.cpp
@@ -83,7 +83,6 @@ TEST_F(RosBag2PlayTestFixture, play_next_playing_all_messages_without_delays) {
   player->pause();
   ASSERT_TRUE(player->is_paused());
 
-  auto player_future = std::async(std::launch::async, [&] {player->wait_for_playback_to_end();});
   player->play();
   player->wait_for_playback_to_start();
 
@@ -99,7 +98,7 @@ TEST_F(RosBag2PlayTestFixture, play_next_playing_all_messages_without_delays) {
   ASSERT_THAT(replay_time, Lt(std::chrono::seconds(2)));
   ASSERT_TRUE(player->is_paused());
   player->resume();
-  player_future.get();
+  player->wait_for_playback_to_end();
   await_received_messages.get();
 
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1");
@@ -138,7 +137,6 @@ TEST_F(RosBag2PlayTestFixture, play_next_playing_one_by_one_messages_with_the_sa
   player->pause();
   ASSERT_TRUE(player->is_paused());
 
-  auto player_future = std::async(std::launch::async, [&] {player->wait_for_playback_to_end();});
   player->play();
 
   ASSERT_TRUE(player->is_paused());
@@ -153,7 +151,7 @@ TEST_F(RosBag2PlayTestFixture, play_next_playing_one_by_one_messages_with_the_sa
   ASSERT_EQ(played_messages, messages.size());
   ASSERT_TRUE(player->is_paused());
   player->resume();
-  player_future.get();
+  player->wait_for_playback_to_end();
   await_received_messages.get();
 
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1");
@@ -192,7 +190,6 @@ TEST_F(RosBag2PlayTestFixture, play_respect_messages_timing_after_play_next) {
   player->pause();
   ASSERT_TRUE(player->is_paused());
 
-  auto player_future = std::async(std::launch::async, [&] {player->wait_for_playback_to_end();});
   player->play();
 
   ASSERT_TRUE(player->is_paused());
@@ -201,7 +198,7 @@ TEST_F(RosBag2PlayTestFixture, play_respect_messages_timing_after_play_next) {
   ASSERT_TRUE(player->is_paused());
   player->resume();
   auto start = std::chrono::steady_clock::now();
-  player_future.get();
+  player->wait_for_playback_to_end();
   auto replay_time = std::chrono::steady_clock::now() - start;
 
   auto expected_replay_time =
@@ -247,14 +244,13 @@ TEST_F(RosBag2PlayTestFixture, player_can_resume_after_play_next) {
   player->pause();
   ASSERT_TRUE(player->is_paused());
 
-  auto player_future = std::async(std::launch::async, [&] {player->wait_for_playback_to_end();});
   player->play();
 
   ASSERT_TRUE(player->is_paused());
   ASSERT_TRUE(player->play_next());
   ASSERT_TRUE(player->is_paused());
   player->resume();
-  player_future.get();
+  player->wait_for_playback_to_end();
   await_received_messages.get();
 
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1");
@@ -304,7 +300,6 @@ TEST_F(RosBag2PlayTestFixture, play_next_playing_only_filtered_topics) {
   player->pause();
   ASSERT_TRUE(player->is_paused());
 
-  auto player_future = std::async(std::launch::async, [&] {player->wait_for_playback_to_end();});
   player->play();
 
   ASSERT_TRUE(player->is_paused());
@@ -318,7 +313,7 @@ TEST_F(RosBag2PlayTestFixture, play_next_playing_only_filtered_topics) {
 
   ASSERT_TRUE(player->is_paused());
   player->resume();
-  player_future.get();
+  player->wait_for_playback_to_end();
   await_received_messages.get();
 
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1");

--- a/rosbag2_transport/test/rosbag2_transport/test_play_publish_clock.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_publish_clock.cpp
@@ -77,10 +77,9 @@ public:
 
     auto await_received_messages = sub_->spin_subscriptions();
 
-    auto player_future = std::async(std::launch::async, [&] {player->wait_for_playback_to_end();});
     player->play();
+    player->wait_for_playback_to_end();
 
-    player_future.get();
     await_received_messages.get();
     exec.cancel();
     spin_thread.join();

--- a/rosbag2_transport/test/rosbag2_transport/test_play_publish_clock.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_publish_clock.cpp
@@ -78,7 +78,7 @@ public:
     auto await_received_messages = sub_->spin_subscriptions();
 
     player->play();
-    player->wait_for_playback_to_end();
+    player->wait_for_playback_to_finish();
 
     await_received_messages.get();
     exec.cancel();

--- a/rosbag2_transport/test/rosbag2_transport/test_play_seek.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_seek.cpp
@@ -115,7 +115,6 @@ TEST_P(RosBag2PlaySeekTestFixture, seek_back_in_time) {
   player->pause();
   ASSERT_TRUE(player->is_paused());
 
-  auto player_future = std::async(std::launch::async, [&] {player->wait_for_playback_to_end();});
   player->play();
 
   EXPECT_TRUE(player->is_paused());
@@ -131,7 +130,7 @@ TEST_P(RosBag2PlaySeekTestFixture, seek_back_in_time) {
   EXPECT_TRUE(player->play_next());
   EXPECT_TRUE(player->play_next());
   player->resume();
-  player_future.get();
+  player->wait_for_playback_to_end();
   await_received_messages.get();
 
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1");
@@ -163,7 +162,6 @@ TEST_P(RosBag2PlaySeekTestFixture, seek_with_timestamp_later_than_in_last_messag
   player->pause();
   ASSERT_TRUE(player->is_paused());
 
-  auto player_future = std::async(std::launch::async, [&] {player->wait_for_playback_to_end();});
   player->play();
 
   EXPECT_TRUE(player->is_paused());
@@ -175,7 +173,7 @@ TEST_P(RosBag2PlaySeekTestFixture, seek_with_timestamp_later_than_in_last_messag
   // shouldn't be able to keep playing since we're at end of bag
   EXPECT_FALSE(player->play_next());
   player->resume();
-  player_future.get();
+  player->wait_for_playback_to_end();
   await_received_messages.get();
 
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1");
@@ -198,7 +196,6 @@ TEST_P(RosBag2PlaySeekTestFixture, seek_forward) {
   player->pause();
   ASSERT_TRUE(player->is_paused());
 
-  auto player_future = std::async(std::launch::async, [&] {player->wait_for_playback_to_end();});
   player->play();
 
   EXPECT_TRUE(player->is_paused());
@@ -208,7 +205,7 @@ TEST_P(RosBag2PlaySeekTestFixture, seek_forward) {
   player->seek((start_time_ms_ + message_spacing_ms_ * 2) * 1000000);
   EXPECT_TRUE(player->play_next());
   player->resume();
-  player_future.get();
+  player->wait_for_playback_to_end();
   await_received_messages.get();
 
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1");
@@ -237,7 +234,6 @@ TEST_P(RosBag2PlaySeekTestFixture, seek_back_in_time_from_the_end_of_the_bag) {
   player->pause();
   ASSERT_TRUE(player->is_paused());
 
-  auto player_future = std::async(std::launch::async, [&] {player->wait_for_playback_to_end();});
   player->play();
 
   EXPECT_TRUE(player->is_paused());
@@ -251,7 +247,7 @@ TEST_P(RosBag2PlaySeekTestFixture, seek_back_in_time_from_the_end_of_the_bag) {
   player->seek((start_time_ms_ + message_spacing_ms_ * 2) * 1000000);
   EXPECT_TRUE(player->play_next());
   player->resume();
-  player_future.get();
+  player->wait_for_playback_to_end();
   await_received_messages.get();
 
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1");
@@ -284,7 +280,6 @@ TEST_P(RosBag2PlaySeekTestFixture, seek_forward_from_the_end_of_the_bag) {
   player->pause();
   ASSERT_TRUE(player->is_paused());
 
-  auto player_future = std::async(std::launch::async, [&] {player->wait_for_playback_to_end();});
   player->play();
 
   EXPECT_TRUE(player->is_paused());
@@ -298,7 +293,7 @@ TEST_P(RosBag2PlaySeekTestFixture, seek_forward_from_the_end_of_the_bag) {
   player->seek((start_time_ms_ + message_spacing_ms_ * (num_msgs_in_bag_ - 1)) * 1000000 + 1);
   EXPECT_FALSE(player->play_next());
   player->resume();
-  player_future.get();
+  player->wait_for_playback_to_end();
   await_received_messages.get();
 
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1");

--- a/rosbag2_transport/test/rosbag2_transport/test_play_seek.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_seek.cpp
@@ -130,7 +130,7 @@ TEST_P(RosBag2PlaySeekTestFixture, seek_back_in_time) {
   EXPECT_TRUE(player->play_next());
   EXPECT_TRUE(player->play_next());
   player->resume();
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
   await_received_messages.get();
 
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1");
@@ -173,7 +173,7 @@ TEST_P(RosBag2PlaySeekTestFixture, seek_with_timestamp_later_than_in_last_messag
   // shouldn't be able to keep playing since we're at end of bag
   EXPECT_FALSE(player->play_next());
   player->resume();
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
   await_received_messages.get();
 
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1");
@@ -205,7 +205,7 @@ TEST_P(RosBag2PlaySeekTestFixture, seek_forward) {
   player->seek((start_time_ms_ + message_spacing_ms_ * 2) * 1000000);
   EXPECT_TRUE(player->play_next());
   player->resume();
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
   await_received_messages.get();
 
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1");
@@ -247,7 +247,7 @@ TEST_P(RosBag2PlaySeekTestFixture, seek_back_in_time_from_the_end_of_the_bag) {
   player->seek((start_time_ms_ + message_spacing_ms_ * 2) * 1000000);
   EXPECT_TRUE(player->play_next());
   player->resume();
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
   await_received_messages.get();
 
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1");
@@ -293,7 +293,7 @@ TEST_P(RosBag2PlaySeekTestFixture, seek_forward_from_the_end_of_the_bag) {
   player->seek((start_time_ms_ + message_spacing_ms_ * (num_msgs_in_bag_ - 1)) * 1000000 + 1);
   EXPECT_FALSE(player->play_next());
   player->resume();
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
   await_received_messages.get();
 
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>("/topic1");

--- a/rosbag2_transport/test/rosbag2_transport/test_play_services.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_services.cpp
@@ -414,7 +414,7 @@ TEST_F(PlaySrvsTest, stop_in_pause) {
   player_->wait_for_playback_to_start();
   service_call_stop();
   // playback shall successfully finish after "Stop" without rclcpp::shutdown()
-  player_->wait_for_playback_to_end();
+  player_->wait_for_playback_to_finish();
   expect_messages(false);
 }
 
@@ -444,6 +444,6 @@ TEST_F(PlaySrvsTest, stop_in_active_play) {
   ASSERT_TRUE(cv.wait_for(lk, 2s, [&] {return calls == 1;}));
   service_call_stop();
   // playback shall successfully finish after "Stop" without rclcpp::shutdown()
-  player_->wait_for_playback_to_end();
+  player_->wait_for_playback_to_finish();
   ASSERT_EQ(calls, 1);
 }

--- a/rosbag2_transport/test/rosbag2_transport/test_play_services.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_services.cpp
@@ -412,9 +412,9 @@ TEST_F(PlaySrvsTest, stop_in_pause) {
   ASSERT_TRUE(player_->is_paused());
   // Make sure that player reached out main play loop
   player_->wait_for_playback_to_start();
-  auto play_future = std::async(std::launch::async, [&] {player_->wait_for_playback_to_end();});
   service_call_stop();
-  play_future.get();
+  // playback shall successfully finish after "Stop" without rclcpp::shutdown()
+  player_->wait_for_playback_to_end();
   expect_messages(false);
 }
 
@@ -442,8 +442,8 @@ TEST_F(PlaySrvsTest, stop_in_active_play) {
   ASSERT_FALSE(player_->is_paused());
   // Wait until first message is going to be published in active playback mode
   ASSERT_TRUE(cv.wait_for(lk, 2s, [&] {return calls == 1;}));
-  auto play_future = std::async(std::launch::async, [&] {player_->wait_for_playback_to_end();});
   service_call_stop();
-  play_future.get();
+  // playback shall successfully finish after "Stop" without rclcpp::shutdown()
+  player_->wait_for_playback_to_end();
   ASSERT_EQ(calls, 1);
 }

--- a/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
@@ -85,9 +85,8 @@ TEST_F(PlayerTestFixture, playing_respects_relative_timing_of_stored_messages)
   // we check that time elapsed during playing is at least the time difference between the two
   // messages
   auto start = clock.now();
-  auto player_future = std::async(std::launch::async, [&] {player->wait_for_playback_to_end();});
   player->play();
-  player_future.get();
+  player->wait_for_playback_to_end();
   auto replay_time = clock.now() - start;
   ASSERT_THAT(replay_time, Gt(message_time_difference));
 }
@@ -99,9 +98,8 @@ TEST_F(PlayerTestFixture, playing_rate_2x)
     std::move(reader), storage_options_, play_options_);
 
   auto start = clock.now();
-  auto player_future = std::async(std::launch::async, [&] {player->wait_for_playback_to_end();});
   player->play();
-  player_future.get();
+  player->wait_for_playback_to_end();
   auto replay_time = clock.now() - start;
 
   ASSERT_THAT(replay_time, Gt(message_time_difference * 0.5));
@@ -115,9 +113,8 @@ TEST_F(PlayerTestFixture, playing_rate_1x)
     std::move(reader), storage_options_, play_options_);
 
   auto start = clock.now();
-  auto player_future = std::async(std::launch::async, [&] {player->wait_for_playback_to_end();});
   player->play();
-  player_future.get();
+  player->wait_for_playback_to_end();
   auto replay_time = clock.now() - start;
   ASSERT_THAT(replay_time, Gt(message_time_difference));
 }
@@ -129,9 +126,8 @@ TEST_F(PlayerTestFixture, playing_rate_halfx)
     std::move(reader), storage_options_, play_options_);
 
   auto start = clock.now();
-  auto player_future = std::async(std::launch::async, [&] {player->wait_for_playback_to_end();});
   player->play();
-  player_future.get();
+  player->wait_for_playback_to_end();
   auto replay_time = clock.now() - start;
   ASSERT_THAT(replay_time, Gt(message_time_difference * 2.0));
 }
@@ -144,9 +140,8 @@ TEST_F(PlayerTestFixture, playing_rate_zero)
     std::move(reader), storage_options_, play_options_);
 
   auto start = clock.now();
-  auto player_future = std::async(std::launch::async, [&] {player->wait_for_playback_to_end();});
   player->play();
-  player_future.get();
+  player->wait_for_playback_to_end();
   auto replay_time = clock.now() - start;
   ASSERT_THAT(replay_time, Gt(message_time_difference));
 }
@@ -159,9 +154,8 @@ TEST_F(PlayerTestFixture, playing_rate_negative)
     std::move(reader), storage_options_, play_options_);
 
   auto start = clock.now();
-  auto player_future = std::async(std::launch::async, [&] {player->wait_for_playback_to_end();});
   player->play();
-  player_future.get();
+  player->wait_for_playback_to_end();
   auto replay_time = clock.now() - start;
   ASSERT_THAT(replay_time, Gt(message_time_difference));
 }
@@ -178,9 +172,8 @@ TEST_F(PlayerTestFixture, playing_respects_delay)
     std::move(reader), storage_options_, play_options_);
 
   auto start = clock.now();
-  auto player_future = std::async(std::launch::async, [&] {player->wait_for_playback_to_end();});
   player->play();
-  player_future.get();
+  player->wait_for_playback_to_end();
   auto replay_time = clock.now() - start;
 
   EXPECT_THAT(replay_time, Gt(lower_expected_duration));
@@ -198,9 +191,8 @@ TEST_F(PlayerTestFixture, play_ignores_invalid_delay)
     std::move(reader), storage_options_, play_options_);
 
   auto start = clock.now();
-  auto player_future = std::async(std::launch::async, [&] {player->wait_for_playback_to_end();});
   player->play();
-  player_future.get();
+  player->wait_for_playback_to_end();
   auto replay_time = clock.now() - start;
 
   EXPECT_THAT(replay_time, Gt(lower_expected_duration));
@@ -221,9 +213,8 @@ TEST_F(PlayerTestFixture, play_respects_start_offset)
     std::move(reader), storage_options_, play_options_);
 
   auto start = clock.now();
-  auto player_future = std::async(std::launch::async, [&] {player->wait_for_playback_to_end();});
   player->play();
-  player_future.get();
+  player->wait_for_playback_to_end();
   auto replay_duration = clock.now() - start;
 
   EXPECT_THAT(replay_duration, Gt(lower_expected_duration));
@@ -242,9 +233,8 @@ TEST_F(PlayerTestFixture, play_ignores_invalid_start_offset)
     std::move(reader), storage_options_, play_options_);
 
   auto start = clock.now();
-  auto player_future = std::async(std::launch::async, [&] {player->wait_for_playback_to_end();});
   player->play();
-  player_future.get();
+  player->wait_for_playback_to_end();
   auto replay_duration = clock.now() - start;
 
   EXPECT_THAT(replay_duration, Gt(lower_expected_duration));

--- a/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_timing.cpp
@@ -86,7 +86,7 @@ TEST_F(PlayerTestFixture, playing_respects_relative_timing_of_stored_messages)
   // messages
   auto start = clock.now();
   player->play();
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
   auto replay_time = clock.now() - start;
   ASSERT_THAT(replay_time, Gt(message_time_difference));
 }
@@ -99,7 +99,7 @@ TEST_F(PlayerTestFixture, playing_rate_2x)
 
   auto start = clock.now();
   player->play();
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
   auto replay_time = clock.now() - start;
 
   ASSERT_THAT(replay_time, Gt(message_time_difference * 0.5));
@@ -114,7 +114,7 @@ TEST_F(PlayerTestFixture, playing_rate_1x)
 
   auto start = clock.now();
   player->play();
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
   auto replay_time = clock.now() - start;
   ASSERT_THAT(replay_time, Gt(message_time_difference));
 }
@@ -127,7 +127,7 @@ TEST_F(PlayerTestFixture, playing_rate_halfx)
 
   auto start = clock.now();
   player->play();
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
   auto replay_time = clock.now() - start;
   ASSERT_THAT(replay_time, Gt(message_time_difference * 2.0));
 }
@@ -141,7 +141,7 @@ TEST_F(PlayerTestFixture, playing_rate_zero)
 
   auto start = clock.now();
   player->play();
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
   auto replay_time = clock.now() - start;
   ASSERT_THAT(replay_time, Gt(message_time_difference));
 }
@@ -155,7 +155,7 @@ TEST_F(PlayerTestFixture, playing_rate_negative)
 
   auto start = clock.now();
   player->play();
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
   auto replay_time = clock.now() - start;
   ASSERT_THAT(replay_time, Gt(message_time_difference));
 }
@@ -173,7 +173,7 @@ TEST_F(PlayerTestFixture, playing_respects_delay)
 
   auto start = clock.now();
   player->play();
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
   auto replay_time = clock.now() - start;
 
   EXPECT_THAT(replay_time, Gt(lower_expected_duration));
@@ -192,7 +192,7 @@ TEST_F(PlayerTestFixture, play_ignores_invalid_delay)
 
   auto start = clock.now();
   player->play();
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
   auto replay_time = clock.now() - start;
 
   EXPECT_THAT(replay_time, Gt(lower_expected_duration));
@@ -214,7 +214,7 @@ TEST_F(PlayerTestFixture, play_respects_start_offset)
 
   auto start = clock.now();
   player->play();
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
   auto replay_duration = clock.now() - start;
 
   EXPECT_THAT(replay_duration, Gt(lower_expected_duration));
@@ -234,7 +234,7 @@ TEST_F(PlayerTestFixture, play_ignores_invalid_start_offset)
 
   auto start = clock.now();
   player->play();
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
   auto replay_duration = clock.now() - start;
 
   EXPECT_THAT(replay_duration, Gt(lower_expected_duration));

--- a/rosbag2_transport/test/rosbag2_transport/test_play_topic_remap.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_topic_remap.cpp
@@ -67,7 +67,7 @@ TEST_F(RosBag2PlayTestFixture, recorded_message_is_played_on_remapped_topic) {
     std::move(reader), storage_options_, play_options_);
 
   ASSERT_TRUE(player->play());
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
 
   await_received_messages.get();
 

--- a/rosbag2_transport/test/rosbag2_transport/test_play_topic_remap.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_topic_remap.cpp
@@ -64,11 +64,10 @@ TEST_F(RosBag2PlayTestFixture, recorded_message_is_played_on_remapped_topic) {
   auto await_received_messages = sub_->spin_subscriptions();
 
   auto player = std::make_shared<rosbag2_transport::Player>(
-    std::move(
-      reader), storage_options_, play_options_);
-  auto player_future = std::async(std::launch::async, [&] {player->wait_for_playback_to_end();});
+    std::move(reader), storage_options_, play_options_);
+
   ASSERT_TRUE(player->play());
-  player_future.get();
+  player->wait_for_playback_to_end();
 
   await_received_messages.get();
 

--- a/rosbag2_transport/test/rosbag2_transport/test_play_until.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_until.cpp
@@ -101,10 +101,8 @@ TEST_F(RosBag2PlayUntilTestFixture, play_until_none_are_played_due_to_timestamp)
     player->add_on_play_message_post_callback(mock_post_callback.AsStdFunction());
   ASSERT_NE(post_callback_handle, Player::invalid_callback_handle);
 
-  auto play_future_result =
-    std::async(std::launch::async, [&] {player->wait_for_playback_to_end();});
   ASSERT_TRUE(player->play());
-  play_future_result.get();
+  player->wait_for_playback_to_end();
 }
 
 TEST_F(RosBag2PlayUntilTestFixture, play_until_less_than_the_total_duration)
@@ -138,18 +136,17 @@ TEST_F(RosBag2PlayUntilTestFixture, play_until_less_than_the_total_duration)
   ASSERT_TRUE(sub_->spin_and_wait_for_matched(player_->get_list_of_publishers(), 5s));
 
   auto await_received_messages = sub_->spin_subscriptions();
-  auto player_future = std::async(std::launch::async, [&] {player_->wait_for_playback_to_end();});
   ASSERT_TRUE(player_->play());
-  player_future.get();
+  player_->wait_for_playback_to_end();
 
   // Playing one more time with play_next() to save time and count messages.
   player_->pause();
-  player_future = std::async(std::launch::async, [&] {player_->wait_for_playback_to_end();});
   player_->play();
   ASSERT_TRUE(player_->play_next());
   ASSERT_FALSE(player_->play_next());
   player_->resume();
-  player_future.get();
+  player_->wait_for_playback_to_end();
+
   await_received_messages.get();
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>(kTopic1_);
   EXPECT_THAT(replayed_topic1, SizeIs(2));
@@ -211,14 +208,13 @@ TEST_F(RosBag2PlayUntilTestFixture, play_should_return_false_when_interrupted)
 
   auto await_received_messages = sub_->spin_subscriptions();
   player_->pause();
-  auto player_future = std::async(std::launch::async, [&] {player_->wait_for_playback_to_end();});
   player_->play();
   player_->wait_for_playback_to_start();
   ASSERT_TRUE(player_->is_paused());
   ASSERT_FALSE(player_->play());
 
   player_->resume();
-  player_future.get();
+  player_->wait_for_playback_to_end();
   await_received_messages.get();
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>(kTopic1_);
   EXPECT_THAT(replayed_topic1, SizeIs(1));
@@ -297,9 +293,8 @@ TEST_F(RosBag2PlayUntilTestFixture, play_until_is_equal_to_the_total_duration)
   ASSERT_TRUE(sub_->spin_and_wait_for_matched(player_->get_list_of_publishers(), 5s));
 
   auto await_received_messages = sub_->spin_subscriptions();
-  auto play_future = std::async(std::launch::async, [&] {player_->wait_for_playback_to_end();});
   ASSERT_TRUE(player_->play());
-  play_future.get();
+  player_->wait_for_playback_to_end();
 
   await_received_messages.get();
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>(kTopic1_);

--- a/rosbag2_transport/test/rosbag2_transport/test_play_until.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_play_until.cpp
@@ -102,7 +102,7 @@ TEST_F(RosBag2PlayUntilTestFixture, play_until_none_are_played_due_to_timestamp)
   ASSERT_NE(post_callback_handle, Player::invalid_callback_handle);
 
   ASSERT_TRUE(player->play());
-  player->wait_for_playback_to_end();
+  player->wait_for_playback_to_finish();
 }
 
 TEST_F(RosBag2PlayUntilTestFixture, play_until_less_than_the_total_duration)
@@ -137,7 +137,7 @@ TEST_F(RosBag2PlayUntilTestFixture, play_until_less_than_the_total_duration)
 
   auto await_received_messages = sub_->spin_subscriptions();
   ASSERT_TRUE(player_->play());
-  player_->wait_for_playback_to_end();
+  player_->wait_for_playback_to_finish();
 
   // Playing one more time with play_next() to save time and count messages.
   player_->pause();
@@ -145,7 +145,7 @@ TEST_F(RosBag2PlayUntilTestFixture, play_until_less_than_the_total_duration)
   ASSERT_TRUE(player_->play_next());
   ASSERT_FALSE(player_->play_next());
   player_->resume();
-  player_->wait_for_playback_to_end();
+  player_->wait_for_playback_to_finish();
 
   await_received_messages.get();
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>(kTopic1_);
@@ -214,7 +214,7 @@ TEST_F(RosBag2PlayUntilTestFixture, play_should_return_false_when_interrupted)
   ASSERT_FALSE(player_->play());
 
   player_->resume();
-  player_->wait_for_playback_to_end();
+  player_->wait_for_playback_to_finish();
   await_received_messages.get();
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>(kTopic1_);
   EXPECT_THAT(replayed_topic1, SizeIs(1));
@@ -294,7 +294,7 @@ TEST_F(RosBag2PlayUntilTestFixture, play_until_is_equal_to_the_total_duration)
 
   auto await_received_messages = sub_->spin_subscriptions();
   ASSERT_TRUE(player_->play());
-  player_->wait_for_playback_to_end();
+  player_->wait_for_playback_to_finish();
 
   await_received_messages.get();
   auto replayed_topic1 = sub_->get_received_messages<test_msgs::msg::BasicTypes>(kTopic1_);

--- a/rosbag2_transport/test/rosbag2_transport/test_player_stop.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_player_stop.cpp
@@ -77,9 +77,9 @@ TEST_F(Rosbag2PlayerStopTestFixture, stop_playback_in_pause_mode_explicit) {
   player.pause();
   ASSERT_TRUE(player.is_paused());
 
+  player.play();
   auto play_future_result =
     std::async(std::launch::async, [&] {player.wait_for_playback_to_end();});
-  player.play();
   EXPECT_TRUE(player.play_next());
   player.stop();
   ASSERT_EQ(play_future_result.wait_for(1s), std::future_status::ready);
@@ -92,9 +92,9 @@ TEST_F(Rosbag2PlayerStopTestFixture, stop_playback_in_pause_mode_implicit) {
     player.pause();
     ASSERT_TRUE(player.is_paused());
 
+    player.play();
     play_future_result =
       std::async(std::launch::async, [&] {player.wait_for_playback_to_end();});
-    player.play();
     EXPECT_TRUE(player.play_next());
   }
   ASSERT_EQ(play_future_result.wait_for(1s), std::future_status::ready);
@@ -119,10 +119,10 @@ TEST_F(Rosbag2PlayerStopTestFixture, stop_playback_explicit) {
 
   player.pause();
   ASSERT_TRUE(player.is_paused());
-  auto play_future_result =
-    std::async(std::launch::async, [&] {player.wait_for_playback_to_end();});
   player.play();
   player.wait_for_playback_to_start();
+  auto play_future_result =
+    std::async(std::launch::async, [&] {player.wait_for_playback_to_end();});
   ASSERT_TRUE(player.is_paused());
   {
     std::unique_lock<std::mutex> lk{m};
@@ -157,10 +157,10 @@ TEST_F(Rosbag2PlayerStopTestFixture, stop_playback_implict) {
     player.pause();
     ASSERT_TRUE(player.is_paused());
 
-    play_future_result =
-      std::async(std::launch::async, [&] {player.wait_for_playback_to_end();});
     player.play();
     player.wait_for_playback_to_start();
+    play_future_result =
+      std::async(std::launch::async, [&] {player.wait_for_playback_to_end();});
     ASSERT_TRUE(player.is_paused());
 
     std::unique_lock<std::mutex> lk{m};

--- a/rosbag2_transport/test/rosbag2_transport/test_player_stop.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_player_stop.cpp
@@ -78,11 +78,9 @@ TEST_F(Rosbag2PlayerStopTestFixture, stop_playback_in_pause_mode_explicit) {
   ASSERT_TRUE(player.is_paused());
 
   player.play();
-  auto play_future_result =
-    std::async(std::launch::async, [&] { player.wait_for_playback_to_finish();});
   EXPECT_TRUE(player.play_next());
   player.stop();
-  ASSERT_EQ(play_future_result.wait_for(1s), std::future_status::ready);
+  ASSERT_TRUE(player.wait_for_playback_to_finish(1s));
 }
 
 TEST_F(Rosbag2PlayerStopTestFixture, stop_playback_in_pause_mode_implicit) {
@@ -94,7 +92,7 @@ TEST_F(Rosbag2PlayerStopTestFixture, stop_playback_in_pause_mode_implicit) {
 
     player.play();
     play_future_result =
-      std::async(std::launch::async, [&] { player.wait_for_playback_to_finish();});
+      std::async(std::launch::async, [&] {player.wait_for_playback_to_finish();});
     EXPECT_TRUE(player.play_next());
   }
   ASSERT_EQ(play_future_result.wait_for(1s), std::future_status::ready);
@@ -121,8 +119,6 @@ TEST_F(Rosbag2PlayerStopTestFixture, stop_playback_explicit) {
   ASSERT_TRUE(player.is_paused());
   player.play();
   player.wait_for_playback_to_start();
-  auto play_future_result =
-    std::async(std::launch::async, [&] { player.wait_for_playback_to_finish();});
   ASSERT_TRUE(player.is_paused());
   {
     std::unique_lock<std::mutex> lk{m};
@@ -132,7 +128,7 @@ TEST_F(Rosbag2PlayerStopTestFixture, stop_playback_explicit) {
     lk.unlock();
     player.stop();
   }
-  ASSERT_EQ(play_future_result.wait_for(1s), std::future_status::ready);
+  ASSERT_TRUE(player.wait_for_playback_to_finish(1s));
   ASSERT_EQ(calls, 1);
 }
 
@@ -160,7 +156,7 @@ TEST_F(Rosbag2PlayerStopTestFixture, stop_playback_implict) {
     player.play();
     player.wait_for_playback_to_start();
     play_future_result =
-      std::async(std::launch::async, [&] { player.wait_for_playback_to_finish();});
+      std::async(std::launch::async, [&] {player.wait_for_playback_to_finish();});
     ASSERT_TRUE(player.is_paused());
 
     std::unique_lock<std::mutex> lk{m};

--- a/rosbag2_transport/test/rosbag2_transport/test_player_stop.cpp
+++ b/rosbag2_transport/test/rosbag2_transport/test_player_stop.cpp
@@ -79,7 +79,7 @@ TEST_F(Rosbag2PlayerStopTestFixture, stop_playback_in_pause_mode_explicit) {
 
   player.play();
   auto play_future_result =
-    std::async(std::launch::async, [&] {player.wait_for_playback_to_end();});
+    std::async(std::launch::async, [&] { player.wait_for_playback_to_finish();});
   EXPECT_TRUE(player.play_next());
   player.stop();
   ASSERT_EQ(play_future_result.wait_for(1s), std::future_status::ready);
@@ -94,7 +94,7 @@ TEST_F(Rosbag2PlayerStopTestFixture, stop_playback_in_pause_mode_implicit) {
 
     player.play();
     play_future_result =
-      std::async(std::launch::async, [&] {player.wait_for_playback_to_end();});
+      std::async(std::launch::async, [&] { player.wait_for_playback_to_finish();});
     EXPECT_TRUE(player.play_next());
   }
   ASSERT_EQ(play_future_result.wait_for(1s), std::future_status::ready);
@@ -122,7 +122,7 @@ TEST_F(Rosbag2PlayerStopTestFixture, stop_playback_explicit) {
   player.play();
   player.wait_for_playback_to_start();
   auto play_future_result =
-    std::async(std::launch::async, [&] {player.wait_for_playback_to_end();});
+    std::async(std::launch::async, [&] { player.wait_for_playback_to_finish();});
   ASSERT_TRUE(player.is_paused());
   {
     std::unique_lock<std::mutex> lk{m};
@@ -160,7 +160,7 @@ TEST_F(Rosbag2PlayerStopTestFixture, stop_playback_implict) {
     player.play();
     player.wait_for_playback_to_start();
     play_future_result =
-      std::async(std::launch::async, [&] {player.wait_for_playback_to_end();});
+      std::async(std::launch::async, [&] { player.wait_for_playback_to_finish();});
     ASSERT_TRUE(player.is_paused());
 
     std::unique_lock<std::mutex> lk{m};


### PR DESCRIPTION
- Relates https://github.com/ros2/rosbag2/pull/1503
- Addressed multiple race conditions in player and some renames after review
- Fixed multiple race conditions in tests when wait_for_playback_to_end() calls in a separate thread before
Player::play() method. Those race conditions would likely lead to false negative or flaky tests.
- Replaced player_future with wait_for_playback_to_end() to the direct call of the player_->wait_for_playback_to_end() in the most of the places.
- Renamed `wait_for_playback_to_end()` to the `wait_for_playback_to_finish()`
- Use rcpputils::unique_lock for RCPPUTILS TSA guarded mutexes
   - Rationale: To support Clang Thread Safety Analysis
- Removed locally defined TSAUniqueLock which is a duplicate of the rcpputils::unique_lock.
- Removed some unused includes in the `player.cpp`
- Add timeout parameter to the wait_for_playback_to_finish()
   - Rationale: Make wait_for_playback_to_finish(..) to be optionally as a non-blocking call. By default, it could be called without a parameter and will be a blocking call as before.